### PR TITLE
Fix GetFileListRecursive() bug

### DIFF
--- a/ttvfs/VFSTools.cpp
+++ b/ttvfs/VFSTools.cpp
@@ -385,7 +385,7 @@ void GetFileListRecursive(std::string dir, StringList& files, bool withQueriedDi
                 files.push_back(dir + *it);
 
             li.clear();
-            GetDirList(dir.c_str(), li, true);
+            GetDirList(dir.c_str(), li, false);
             for(std::deque<std::string>::iterator it = li.begin(); it != li.end(); ++it)
                 stk.push(dir + *it);
         }
@@ -408,7 +408,7 @@ void GetFileListRecursive(std::string dir, StringList& files, bool withQueriedDi
                 files.push_back(dir + *it);
 
             li.clear();
-            GetDirList(dir.c_str(), li, true);
+            GetDirList(dir.c_str(), li, false);
             for(std::deque<std::string>::iterator it = li.begin(); it != li.end(); ++it)
                 stk.push(dir + *it);
         }


### PR DESCRIPTION
Fixed a bug that caused GetFileListRecursive() to count folders more than once. This was due to calling GetDirList() on each folder with recursive set to true, while also recursively stepping through the folders and calling GetDirList(recursive=true) on each.
