### PR TITLE
Add ttvfs_gen tool to zip and embed directory into application

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,14 @@ if(TTVFS_BUILD_GENERATOR AND NOT TTVFS_SUPPORT_ZIP)
     message(FATAL_ERROR "You must enable TTVFS_SUPPORT_ZIP to use TTVFS_BUILD_GENERATOR")
 endif()
 
+IF("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    SET(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /MTd")
+    SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
+
+    SET(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /MT")
+    SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
+ENDIF("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+
 # Be sure to copy this part to your root CMakeLists.txt if you prefer to use CMake for configuring
 # instead of editing the config header directly!
 # If you edit the header, this is not necessary.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,16 @@ cmake_minimum_required(VERSION 2.6)
 project(ttvfs)
 
 option(TTVFS_BUILD_EXAMPLES "Build examples?" FALSE)
+option(TTVFS_BUILD_GENERATOR "Build the embedded zip archive generator tool." TRUE)
 option(TTVFS_SUPPORT_ZIP "Build support for zip archives?" TRUE)
 option(TTVFS_LARGEFILE_SUPPORT "Enable support for files > 4 GB? (experimental!)" TRUE)
 option(TTVFS_IGNORE_CASE "Enable full case-insensitivity even on case-sensitive OSes like Linux and alike?" TRUE)
 option(TTVFS_BUILD_CFILEAPI "Build C-style API wrapper" TRUE)
 option(TTVFS_BUILD_TESTS "Build tests" FALSE)
+
+if(TTVFS_BUILD_GENERATOR AND NOT TTVFS_SUPPORT_ZIP)
+    message(FATAL_ERROR "You must enable TTVFS_SUPPORT_ZIP to use TTVFS_BUILD_GENERATOR")
+endif()
 
 # Be sure to copy this part to your root CMakeLists.txt if you prefer to use CMake for configuring
 # instead of editing the config header directly!
@@ -54,6 +59,10 @@ endif()
 
 if(TTVFS_BUILD_CFILEAPI)
     add_subdirectory(ttvfs_cfileapi)
+endif()
+
+if(TTVFS_BUILD_GENERATOR AND TTVFS_SUPPORT_ZIP)
+    add_subdirectory(ttvfs_gen)
 endif()
 
 if(TTVFS_BUILD_EXAMPLES)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 include_directories(${TTVFS_INCLUDE_DIRS})
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 add_executable(example1 example1.cpp)
 add_executable(example2 example2.cpp)
@@ -28,6 +29,26 @@ if(TTVFS_SUPPORT_ZIP)
 
     add_executable(example9 example9.cpp)
     target_link_libraries(example9 ttvfs ttvfs_zip)
+
+    if(TTVFS_BUILD_GENERATOR)
+        add_custom_command(
+            OUTPUT
+                ${CMAKE_CURRENT_BINARY_DIR}/res.c
+                ${CMAKE_CURRENT_BINARY_DIR}/res.h
+            COMMAND ttvfs_gen ResourceData ResourceSize
+                ${CMAKE_CURRENT_SOURCE_DIR}/res
+                ${CMAKE_CURRENT_BINARY_DIR}/res.c
+                ${CMAKE_CURRENT_BINARY_DIR}/res.h
+            DEPENDS ttvfs_gen
+            COMMENT "Generating resource file for example11"
+        )
+        add_executable(example11
+            example11.cpp
+            ${CMAKE_CURRENT_BINARY_DIR}/res.c
+            ${CMAKE_CURRENT_BINARY_DIR}/res.h
+        )
+        target_link_libraries(example11 ttvfs ttvfs_zip)
+    endif()
 endif()
 
 if(TTVFS_BUILD_CFILEAPI)

--- a/examples/example11.cpp
+++ b/examples/example11.cpp
@@ -1,0 +1,54 @@
+
+/* ttvfs example #1 - Embedding a zip file in the code */
+
+#include <stdio.h>
+#include <ttvfs.h>
+#include <ttvfs_zip.h>
+
+#include "res.h"
+
+int main(int argc, char *argv[])
+{
+    ttvfs::Root vfs;
+    // Note that we're not adding a disk loader here.
+    vfs.AddArchiveLoader(new ttvfs::VFSZipArchiveLoader);
+
+    // By default, the buffer is left untouched when the MemFile is deleted.
+    // Use new because refcounting will delete the file when vfs is destroyed.
+    // Use a CountedPtr so that we don't have to worry about cleaning up if something fails.
+    // The file name is arbitrarily chosen, but the subdir representing the zip file
+    // will have this name.
+    ttvfs::CountedPtr<ttvfs::MemFile> mf = new ttvfs::MemFile("memdata.zip",
+        ResourceData, ResourceSize);
+
+    // Make all files from the archive available in the root.
+    // The MemFile itself can NOT be accessed from the vfs root.
+    if(!vfs.AddArchive(mf, ""))
+    {
+        puts("ERROR adding embedded archive");
+        return 1;
+    }
+
+    char buf[513];
+    size_t bytes = 0;
+    ttvfs::File *vf = vfs.GetFile("a.txt");
+    if(!vf || !vf->open("r") || !(bytes = vf->read(buf, 512)) )
+    {
+        puts("ERROR reading from embedded a.txt");
+        return 2;
+    }
+    buf[bytes] = 0;
+    puts(buf);
+
+    vf = vfs.GetFile("b/c.txt");
+    if(!vf || !vf->open("r") || !(bytes = vf->read(buf, 512)) )
+    {
+        puts("ERROR reading from embedded a.txt");
+        return 2;
+    }
+    buf[bytes] = 0;
+    puts(buf);
+
+    return 0;
+}
+

--- a/examples/res/a.txt
+++ b/examples/res/a.txt
@@ -1,0 +1,1 @@
+This is an example file.

--- a/examples/res/b/c.txt
+++ b/examples/res/b/c.txt
@@ -1,0 +1,1 @@
+This is another example file.

--- a/ttvfs/CMakeLists.txt
+++ b/ttvfs/CMakeLists.txt
@@ -30,3 +30,8 @@ set(ttvfs_SRC
 )
 
 add_library(ttvfs ${ttvfs_SRC})
+
+install(TARGETS ttvfs DESTINATION lib)
+
+install(DIRECTORY ./ DESTINATION include/ttvfs
+    FILES_MATCHING PATTERN "*.h")

--- a/ttvfs_cfileapi/CMakeLists.txt
+++ b/ttvfs_cfileapi/CMakeLists.txt
@@ -10,3 +10,7 @@ add_library(ttvfs_cfileapi ${cfileapi_SRC})
 
 target_link_libraries(ttvfs_cfileapi ttvfs)
 
+install(TARGETS ttvfs_cfileapi DESTINATION lib)
+
+install(DIRECTORY ./ DESTINATION include/ttvfs
+    FILES_MATCHING PATTERN "*.h")

--- a/ttvfs_gen/CMakeLists.txt
+++ b/ttvfs_gen/CMakeLists.txt
@@ -1,0 +1,12 @@
+
+set(ttvfs_gen_SRC
+    ttvfs_gen.cpp
+)
+
+include_directories(${TTVFS_INCLUDE_DIRS})
+
+add_executable(ttvfs_gen ${ttvfs_gen_SRC})
+
+target_link_libraries(ttvfs_gen ttvfs ttvfs_zip)
+
+install(TARGETS ttvfs_gen DESTINATION bin)

--- a/ttvfs_gen/ttvfs_gen.cpp
+++ b/ttvfs_gen/ttvfs_gen.cpp
@@ -1,0 +1,199 @@
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+
+#include <VFSTools.h>
+#include <miniz.h>
+
+ttvfs::StringList GetRecursiveFileList(const std::string& dirPath)
+{
+    ttvfs::StringList dirs;
+    ttvfs::StringList allFiles;
+
+    (void)ttvfs::GetDirList(dirPath.c_str(), dirs, -1);
+    (void)ttvfs::GetFileList(dirPath.c_str(), allFiles);
+
+    for(std::deque<std::string>::const_iterator it = dirs.begin();
+        it != dirs.end(); ++it)
+    {
+        std::string externalDirPath = dirPath + std::string("/") + (*it);
+        std::string internalDirPath = *it;
+
+        ttvfs::FixPath(externalDirPath);
+
+        ttvfs::StringList files;
+
+        (void)ttvfs::GetFileList(externalDirPath.c_str(), files);
+
+        for(std::deque<std::string>::const_iterator it2 = files.begin();
+            it2 != files.end(); ++it2)
+        {
+            std::string internalPath = internalDirPath +
+                std::string("/") + *it2;
+
+            ttvfs::FixPath(internalPath);
+
+            allFiles.push_back(internalPath);
+        }
+    }
+
+    return allFiles;
+}
+
+int main(int argc, char *argv[])
+{
+    if(6 != argc)
+    {
+        std::cerr << "USAGE: " << argv[0] << " ARRAY_NAME SIZE_NAME "
+            "DIR SOURCE HEADER" << std::endl;
+
+        return EXIT_FAILURE;
+    }
+
+    std::string arrayName = argv[1];
+    std::string sizeName = argv[2];
+    std::string dirPath = argv[3];
+    std::string sourcePath = argv[4];
+    std::string headerPath = argv[5];
+    std::string arrayNameUpper = arrayName;
+
+    std::transform(arrayNameUpper.begin(), arrayNameUpper.end(),
+        arrayNameUpper.begin(), ::toupper);
+
+    ttvfs::StringList files = GetRecursiveFileList(dirPath);
+
+    mz_zip_archive zip;
+    memset(&zip, 0, sizeof(zip));
+
+    if(MZ_FALSE == mz_zip_writer_init_heap(&zip, 0, 128 * 1024))
+    {
+        std::cerr << "mz_zip_writer_init_heap failed" << std::endl;
+
+        return EXIT_FAILURE;
+    }
+
+    for(std::deque<std::string>::const_iterator it = files.begin();
+        it != files.end(); ++it)
+    {
+        std::string externalPath = dirPath + std::string("/") + (*it);
+        std::string internalPath = *it;
+
+        ttvfs::FixPath(externalPath);
+
+        if(MZ_FALSE == mz_zip_writer_add_file(&zip, internalPath.c_str(),
+            externalPath.c_str(), NULL, 0, MZ_DEFAULT_COMPRESSION))
+        {
+            std::cerr << "mz_zip_writer_add_file failed on file "
+                << internalPath << std::endl;
+
+            return EXIT_FAILURE;
+        }
+    }
+
+    unsigned char *pBuf;
+    size_t size;
+
+    if(MZ_FALSE == mz_zip_writer_finalize_heap_archive(&zip,
+        (void**)&pBuf, &size))
+    {
+        std::cerr << "mz_zip_writer_finalize_heap_archive failed" << std::endl;
+
+        return EXIT_FAILURE;
+    }
+
+    if(MZ_FALSE == mz_zip_writer_end(&zip))
+    {
+        std::cerr << "mz_zip_writer_end failed" << std::endl;
+
+        return EXIT_FAILURE;
+    }
+
+    std::ofstream header;
+    header.open(headerPath.c_str(), std::ofstream::out);
+
+    if(!header.good())
+    {
+        std::cerr << "Failed to open header file " << headerPath << std::endl;
+
+        return EXIT_FAILURE;
+    }
+
+    header << "/* THIS FILE IS GENERATED. DO NOT EDIT. "
+        "DO NOT ADD TO CODE REPOSITORY. */" << std::endl;
+    header << std::endl;
+    header << "#ifndef " << arrayNameUpper << "_H" << std::endl;
+    header << "#define " << arrayNameUpper << "_H" << std::endl;
+    header << std::endl;
+    header << "#include <stdio.h>" << std::endl;
+    header << std::endl;
+    header << "#ifdef __cplusplus" << std::endl;
+    header << "extern \"C\" {" << std::endl;
+    header << "#endif" << std::endl;
+    header << std::endl;
+    header << "/** Embedded resource zip file. */" << std::endl;
+    header << "extern unsigned char " << arrayName << "[" << size
+        << "];" << std::endl;
+    header << std::endl;
+    header << "/** Embedded resource zip file size. */" << std::endl;
+    header << "extern size_t " << sizeName << ";" << std::endl;
+    header << std::endl;
+    header << "#ifdef __cplusplus" << std::endl;
+    header << "}" << std::endl;
+    header << "#endif" << std::endl;
+    header << std::endl;
+    header << "#endif /* " << arrayNameUpper << "_H */" << std::endl;
+
+    std::ofstream source;
+    source.open(sourcePath.c_str(), std::ofstream::out);
+
+    if(!source.good())
+    {
+        std::cerr << "Failed to open header file " << sourcePath << std::endl;
+
+        return EXIT_FAILURE;
+    }
+
+    source << "/* THIS FILE IS GENERATED. DO NOT EDIT. "
+        "DO NOT ADD TO CODE REPOSITORY. */" << std::endl;
+    source << std::endl;
+    source << "#include <stdio.h>" << std::endl;
+    source << std::endl;
+    source << "unsigned char " << arrayName << "[" << size
+        << "] = {" << std::endl;
+
+    for(size_t i = 0; i < size; ++i)
+    {
+        if(0 == (i % 8))
+        {
+            source << "    ";
+        }
+
+        source << "0x" << std::hex << std::setw(2) << std::setfill('0')
+            << ((unsigned int)pBuf[i]) << ",";
+
+        if(i != (size - 1))
+        {
+            source << " ";
+        }
+
+        if(7 == (i % 8))
+        {
+            source << std::endl;
+        }
+    }
+
+    if(0 != (size % 8))
+    {
+        source << std::endl;
+    }
+
+    source << "};" << std::endl;
+    source << std::endl;
+    source << "size_t " << sizeName << " = " << std::dec
+        << size << ";" << std::endl;
+
+    return EXIT_SUCCESS;
+}

--- a/ttvfs_zip/CMakeLists.txt
+++ b/ttvfs_zip/CMakeLists.txt
@@ -16,3 +16,10 @@ set(ttvfs_zip_SRC
 include_directories(${TTVFS_INCLUDE_DIRS})
 
 add_library(ttvfs_zip ${ttvfs_zip_SRC})
+
+install(TARGETS ttvfs_zip DESTINATION lib)
+
+install(FILES miniz.c DESTINATION include/ttvfs)
+
+install(DIRECTORY ./ DESTINATION include/ttvfs
+    FILES_MATCHING PATTERN "*.h")

--- a/ttvfs_zip/miniz.c
+++ b/ttvfs_zip/miniz.c
@@ -144,7 +144,7 @@
 // If all macros here are defined the only functionality remaining will be CRC-32, adler-32, tinfl, and tdefl.
 
 // Define MINIZ_NO_STDIO to disable all usage and any functions which rely on stdio for file I/O.
-#define MINIZ_NO_STDIO
+//#define MINIZ_NO_STDIO
 
 // If MINIZ_NO_TIME is specified then the ZIP archive functions will not be able to get the current time, or
 // get/set file times.


### PR DESCRIPTION
This pull request does two things:
1. It adds an install target.
2. It adds a utility called ttvfs_gen that can be used along with add_custom_command to generate a source/header pair of a zip the contains the contents of a directory. This can then be compiled into another application in the same CMake project. See example 11.